### PR TITLE
SPIR-v update and rt resize fix

### DIFF
--- a/assets/gfx/material/bgscroll.fp
+++ b/assets/gfx/material/bgscroll.fp
@@ -1,14 +1,18 @@
-varying mediump vec2 var_texcoord0;
-varying mediump vec2 var_texcoord1;
-varying mediump vec2 var_texcoord2;
+#version 140
 
-uniform lowp sampler2D tex0;
-uniform lowp sampler2D tex1;
+in vec2 var_texcoord0;
+in vec2 var_texcoord1;
+in vec2 var_texcoord2;
+
+out vec4 color_out;
+
+uniform sampler2D tex0;
+uniform sampler2D tex1;
 
 void main()
 {
-    vec4 bg = texture2D(tex0, var_texcoord1.xy);
-    vec4 debris = texture2D(tex1, var_texcoord2.xy);
+    vec4 bg = texture(tex0, var_texcoord1.xy);
+    vec4 debris = texture(tex1, var_texcoord2.xy);
     
-    gl_FragColor = vec4(bg.rgb + debris.rgb,1.0);
+    color_out = vec4(bg.rgb + debris.rgb,1.0);
 }

--- a/assets/gfx/material/bgscroll.vp
+++ b/assets/gfx/material/bgscroll.vp
@@ -1,13 +1,18 @@
-attribute highp vec4 position;
-attribute mediump vec2 texcoord0;
+#version 140
 
-uniform mediump mat4 mtx_worldview;
-uniform mediump mat4 mtx_proj;
-uniform mediump vec4 animation_time;
+uniform vx_uniforms
+{
+    uniform mat4 mtx_worldview;
+    uniform mat4 mtx_proj;
+    uniform vec4 animation_time;
+};
 
-varying mediump vec2 var_texcoord0;
-varying mediump vec2 var_texcoord1;
-varying mediump vec2 var_texcoord2;
+in vec4 position;
+in vec2 texcoord0;
+
+out vec2 var_texcoord0;
+out vec2 var_texcoord1;
+out vec2 var_texcoord2;
 
 void main()
 {

--- a/assets/gfx/material/lightning.fp
+++ b/assets/gfx/material/lightning.fp
@@ -1,8 +1,11 @@
-varying mediump vec2 var_texcoord0;
+#version 140
 
-uniform lowp sampler2D lightning;
+in vec2 var_texcoord0;
+out vec4 color_out;
+
+uniform sampler2D lightning;
 
 void main()
 {
-    gl_FragColor = texture2D(lightning, var_texcoord0.xy);
+    color_out = texture(lightning, var_texcoord0.xy);
 }

--- a/assets/gfx/material/lightning.vp
+++ b/assets/gfx/material/lightning.vp
@@ -1,8 +1,14 @@
-attribute highp vec4 position; 
-attribute mediump vec2 texcoord0;
+#version 140
 
-uniform highp mat4 worldview_proj;
-varying mediump vec2 var_texcoord0;
+uniform vx_uniforms
+{
+    uniform highp mat4 worldview_proj;
+};
+
+in vec4 position; 
+in vec2 texcoord0;
+
+out vec2 var_texcoord0;
 
 void main()
 {

--- a/assets/gfx/material/vertex_tint.fp
+++ b/assets/gfx/material/vertex_tint.fp
@@ -1,11 +1,15 @@
-varying mediump vec2 var_texcoord0;
-varying mediump vec4 var_tint;
+#version 140
 
-uniform lowp sampler2D texture_sampler;
+in vec2 var_texcoord0;
+in vec4 var_tint;
+
+out vec4 color_out;
+
+uniform sampler2D texture_sampler;
 
 void main()
 {
     // Pre-multiply alpha since all runtime textures already are
-    lowp vec4 tint_pm = vec4(var_tint.xyz * var_tint.w, var_tint.w);
-    gl_FragColor = texture2D(texture_sampler, var_texcoord0.xy) * tint_pm;
+    vec4 tint_pm = vec4(var_tint.xyz * var_tint.w, var_tint.w);
+    color_out = texture(texture_sampler, var_texcoord0.xy) * tint_pm;
 }

--- a/assets/gfx/material/vertex_tint.vp
+++ b/assets/gfx/material/vertex_tint.vp
@@ -1,12 +1,16 @@
-uniform highp mat4 view_proj;
+#version 140
 
+uniform vx_uniforms
+{
+    uniform highp mat4 view_proj;
+};
 // positions are in world space
-attribute highp vec4 position;
-attribute mediump vec2 texcoord0;
-attribute mediump vec4 tint;
+in highp vec4 position;
+in mediump vec2 texcoord0;
+in mediump vec4 tint;
 
-varying mediump vec2 var_texcoord0;
-varying mediump vec4 var_tint;
+out vec2 var_texcoord0;
+out vec4 var_tint;
 
 void main()
 {

--- a/assets/mesh_system/render/DeLab.render_script
+++ b/assets/mesh_system/render/DeLab.render_script
@@ -64,7 +64,7 @@ function init(self)
 ------ Offscreen Buffer initialize --------
     self.capture_On = false -- boolean to turn capture on or off
     self.offscreen_buffer = "capture"
-    
+    update_rendertarget(self) -- update rt at launch to adjust for varying screen resolution
 end
 
 function update(self)


### PR DESCRIPTION
- Updated shaders to SPIR-v compatible GLSL code.

- Render script now resizes lightning render target at initialization. To account for unsuspected screen resolutions at launch.