### PR TITLE
Render offscreen buffer after scene will cause a black screen bug on fire (osx)

### DIFF
--- a/assets/mesh_system/render/DeLab.render_script
+++ b/assets/mesh_system/render/DeLab.render_script
@@ -85,9 +85,19 @@ function update(self)
 
     render.set_blend_func(graphics.BLEND_FACTOR_SRC_ALPHA, graphics.BLEND_FACTOR_ONE_MINUS_SRC_ALPHA)
     render.enable_state(graphics.STATE_BLEND)
-    
 
------------- RENDER SCENE  ------------------------------------
+    ------------ RENDER OFFSCREEN BUFFER --------------------------
+    if self.capture_On then -- start rendering only when needed
+
+        render.set_render_target(self.offscreen_buffer) -- set render target offscreen buffer
+        render.clear({[graphics.BUFFER_TYPE_COLOR0_BIT] = self.clear_color}) -- clear the buffer color bit
+        render.draw(self.offscreen_sprite_pred) -- draw the offscreen predicate to the render target
+        render.set_render_target(render.RENDER_TARGET_DEFAULT) -- unbind render target
+
+    end
+    -----------------------------------------------------------
+
+    ------------ RENDER SCENE  ------------------------------------
     render.set_depth_mask(true)
     render.enable_state(graphics.STATE_DEPTH_TEST)
     render.enable_state(graphics.STATE_STENCIL_TEST)
@@ -110,17 +120,6 @@ function update(self)
     --
     render.draw(self.tile_pred, {frustum = frustum_component})
     render.draw(self.particle_pred, {frustum = frustum_component})
-
-    ------------ RENDER OFFSCREEN BUFFER --------------------------
-    if self.capture_On then -- start rendering only when needed
-
-        render.set_render_target(self.offscreen_buffer) -- set render target offscreen buffer
-        render.clear({[graphics.BUFFER_TYPE_COLOR0_BIT] = self.clear_color}) -- clear the buffer color bit
-        render.draw(self.offscreen_sprite_pred) -- draw the offscreen predicate to the render target
-        render.set_render_target(render.RENDER_TARGET_DEFAULT) -- unbind render target
-
-    end
-    -----------------------------------------------------------
     -- debug
     render.draw_debug3d()
     


### PR DESCRIPTION
Fixes the macOS render-order issue where firing bugs out and produce a black screen in the current version. The offscreen buffer now renders before the scene pass. Now works on both osx and html5.